### PR TITLE
[CORENEWS-145] - CSS Duplicate Compilation

### DIFF
--- a/src/configuration/webpack.development.js
+++ b/src/configuration/webpack.development.js
@@ -52,21 +52,12 @@ module.exports = {
                     {
                         loader: 'css-loader',
                         options: {
-                           localIdentName: '[hash:8]',
-                           modules: true
+                            importLoaders: 1,
+                            localIdentName: '[name]__[local]__[hash:base64:5]',
+                            modules: true
                         }
                     },
-                    {
-                        loader: 'postcss-loader',
-                        options: {
-                            plugins: function () {
-                                return [
-                                    require('postcss-import'),
-                                    require('postcss-cssnext')
-                                ]
-                            }
-                        }
-                    }
+                    'postcss-loader'
                 ]
             },
             // babel transpiler

--- a/src/configuration/webpack.production.js
+++ b/src/configuration/webpack.production.js
@@ -47,21 +47,12 @@ module.exports = {
                         {
                             loader: 'css-loader',
                             options: {
-                               localIdentName: '[hash:8]',
-                               modules: true
+                                importLoaders: 1,
+                                localIdentName: '[hash:8]',
+                                modules: true
                             }
                         },
-                        {
-                            loader: 'postcss-loader',
-                            options: {
-                                plugins: function () {
-                                    return [
-                                        require('postcss-import'),
-                                        require('postcss-cssnext')
-                                    ]
-                                }
-                            }
-                        }
+                        'postcss-loader'
                     ]
                 })
             },

--- a/src/structure/src/postcss.config.js
+++ b/src/structure/src/postcss.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    'postcss-import': {},
+    'postcss-cssnext': {
+        browsers: [
+            'last 4 versions',
+            'ios >= 5.1',
+            'and_chr > 41',
+            'last 4 android versions',
+            'ie_mob >= 11'
+        ]
+    }
+};


### PR DESCRIPTION
## Problem

CSS in [`CNN The Source`](https://github.com/turnercode/cnn-the-source) is driven by a `webpack` loader chain `postcss-loader` -> `css-loader`. `css-loader` requires the `importLoaders` option to indicate that loaders are ahead of it in the chain. Since this is not present, `css-loader` "reloads" the untranspiled CSS, resulting in duplicate rules like the following:

```css
.foo {
  margin: var(--spacing) 0;
}

.foo {
  margin: 20px 0;
}
```

## Solution

* Add `importLoaders: 1` so `css-loader` will only load the output from `postcss-loader`
* Add `postcss.config.js` so that `postcss-load-config` does not throw errors if the file is not present.

### Bonus

* Update `localIdentName` in `webpack.development.js` to be `[name]__[local]__[hash:base64:5]` to make debugging easier. This will transpile to a rule like `.Card__container__b39ce`.
