### PR TITLE
[DO NOT MERGE] Replace `System.import` with dynamic import syntax

### DIFF
--- a/src/structure/src/modules/async-route/index.js
+++ b/src/structure/src/modules/async-route/index.js
@@ -5,7 +5,7 @@ import React, { Component, PropTypes } from 'react';
  * ```
  * <Route
  *      path='/test'
- *      component={(props) => (<AsyncRoute props={props} loadingPromise={System.import('./path/to/page/component')} />)}
+ *      component={(props) => (<AsyncRoute props={props} loadingPromise={import('./path/to/page/component')} />)}
  * />
  * ```
  */

--- a/src/structure/src/routes.js
+++ b/src/structure/src/routes.js
@@ -1,12 +1,9 @@
 import React from 'react';
 import AsyncRoute from 'modules/async-route';
 
-// @TODO: find a better implentation for this
-if (global) { global.System = { import() {} } }
-
 const noMatch = {
     component: (props) => (
-        <AsyncRoute props={props} loadingPromise={System.import('./pages/no-match')} />
+        <AsyncRoute props={props} loadingPromise={import('./pages/no-match')} />
     )
 };
 
@@ -15,21 +12,21 @@ const routes = [
         path: '/',
         exact: true,
         component: (props) => (
-            <AsyncRoute props={props} loadingPromise={System.import('./pages/homepage')} />
+            <AsyncRoute props={props} loadingPromise={import('./pages/homepage')} />
         )
     },
     {
         path: '/test',
         exact: true,
         component: (props) => (
-            <AsyncRoute props={props} loadingPromise={System.import('./pages/test')} />
+            <AsyncRoute props={props} loadingPromise={import('./pages/test')} />
         )
     },
     {
         path: '/test/sub',
         exact: false,
         component: (props) => (
-            <AsyncRoute props={props} loadingPromise={System.import('./pages/test-sub')} />
+            <AsyncRoute props={props} loadingPromise={import('./pages/test-sub')} />
         )
     }
 ]; // end of routes || DO NOT ALTER THIS LINE.


### PR DESCRIPTION
`babel-preset-cnn-starter-app` allows parsing of `import()`, and Webpack 2 will transform `import()` [out of the box](https://github.com/webpack/webpack/issues/3098).