### PR TITLE
fix: Warning with setState

### DIFF
--- a/src/structure/src/modules/async-route/index.js
+++ b/src/structure/src/modules/async-route/index.js
@@ -21,11 +21,24 @@ class AsyncRoute extends Component {
         isLoaded: false
     };
 
+    constructor(props) {
+        super(props);
+        this.loaded = this.loaded.bind(this);
+    }
+
     componentDidMount() {
         this.props.loadingPromise.then((module) => {
             this.component = module.default;
-            this.setState({ isLoaded: true });
+            this.loaded();
         });
+    }
+
+    componentWillUnmount() {
+        this.loaded = () => {};
+    }
+
+    loaded() {
+        this.setState({ isLoaded: true });
     }
 
     render() {


### PR DESCRIPTION
## What's New?

Fixes an warning that is being thrown when using React's dev version. I saw this error when trying to load a route but then immediately changing the route before the route's component had time to download.