### PR TITLE
feature: expose return value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /*.log
 .DS_Store
 .idea
+*.sw*

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -8,6 +8,8 @@ const argv = process.argv.slice(3);
 const log = console;
 const validScripts = scripts.map(script => script.value);
 
+
+
 if (validScripts.indexOf(script) !== -1) {
     const command = 'node';
     const args = [
@@ -15,6 +17,23 @@ if (validScripts.indexOf(script) !== -1) {
     ].concat(argv);
 
     const run = spawn(command, args, { stdio: 'inherit' });
+
+    run.on('close', done(process));
 } else {
     log.error(`Command ${script} is not supported.`);
 }
+
+
+
+/*
+ * Exposes the child process return value as the return value for this
+ * execution of the script.
+ */
+function done(process) {
+
+    return function exitWith(code) {
+
+        process.exit(code);
+    }
+}
+

--- a/src/scripts/lint.js
+++ b/src/scripts/lint.js
@@ -8,3 +8,18 @@ const args = [
 ];
 
 const child = spawn(command, args, { stdio: 'inherit' });
+
+child.on('close', done(process));
+
+
+/*
+ * Exposes the child process return value as the return value for this
+ * execution of the script.
+ */
+function done(process) {
+
+    return function exitWith(code) {
+
+        process.exit(code);
+    }
+}


### PR DESCRIPTION
## What's New?
Exposes the return value of the child processes for test and lint command. This way there is a programmatic way of determining if the processes failed.

## How To Test?
1. Pull this down.
2. Write some failing tests.
3. Run `npm test; echo $?`. The last line should return a non zero value.
3. Correct your test and now put some styles out of alphabetical order.
4. Run `npm run lint; echo $?`. The last line should return a non zero value.