### PR TITLE
fix: force production env for analyze

### DIFF
--- a/src/scripts/analyze.js
+++ b/src/scripts/analyze.js
@@ -6,6 +6,9 @@ const resolve = require('path').resolve;
 
 const log = console;
 
+// Set the environment to production.
+process.env.NODE_ENV = 'production';
+
 function viewAnalysis(callback) {
     const command = 'webpack-bundle-analyzer';
     const args = ['stats.json'];


### PR DESCRIPTION
# What
Force production environment when running analyze, else react and some other packages will revert to their development builds.