### PR TITLE
Add logging for Webpack overrides

### DIFF
--- a/src/configuration/server.development.js
+++ b/src/configuration/server.development.js
@@ -6,8 +6,12 @@ const override = resolve(process.cwd(), 'webpack.development.js');
 
 try {
     webpackConfig = require(override);
-} catch (e) {
-    // no override configuration found
+} catch (err) {
+    if (err.code === 'MODULE_NOT_FOUND') {
+        console.log(`No override configuration found at ${override}. Using built-in config.`);
+    } else {
+        throw err;
+    }
 }
 
 const compiler = webpack(webpackConfig);


### PR DESCRIPTION
Instead of swallowing errors when attempting to override Webpack configs, we should handle the case where the override config does not exist, and throw the actual error otherwise. The errors are useful to troubleshoot override configs.