### PR TITLE
feat: set jest setup file when found in client project at `src/setupTests.js`

### DIFF
--- a/src/configuration/jest/index.js
+++ b/src/configuration/jest/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const fs = require('fs');
+
 /**
  * Creates a configuration object to control Jest's behavior.
  *
@@ -8,15 +10,21 @@
  * @param {String}   rootDir    The root directory for the tests
  * @return {Object}             The Jest configuration object
  */
-const createJestConfig = (resolve, rootDir) => ({
-    rootDir,
-    transform: {
-        '^.+\\.(js|jsx)$': resolve('configuration/jest/babelTransform')
-    },
-    moduleNameMapper: {
-        '^.+\\.css$': 'identity-obj-proxy'
-    },
-    moduleDirectories: [ 'node_modules', 'src' ]
-});
+const createJestConfig = (resolve, rootDir) => {
+    const setupFileName = `${rootDir}/src/setupTests.js`;
+    const setupFile = fs.existsSync(setupFileName) ? setupFileName : undefined;
+
+    return {
+        rootDir,
+        transform: {
+            '^.+\\.(js|jsx)$': resolve('configuration/jest/babelTransform')
+        },
+        moduleNameMapper: {
+            '^.+\\.css$': 'identity-obj-proxy'
+        },
+        moduleDirectories: ['node_modules', 'src'],
+        setupTestFrameworkScriptFile: setupFile
+    };
+};
 
 module.exports = createJestConfig;


### PR DESCRIPTION
# What
When running tests, this feature detects the existence of `src/setupTests.js` in the client project and configures jest to run this file before each test.

# Why
When upgrading to react-16; enzyme requires an adapter to be specified or it will fail with: `Enzyme Internal Error: Enzyme expects an adapter to be configured, but found none. `

Currently, there is no way to configure an adapter since `cnn-starter-app` manages the jest config. This solution is based on how `create-react-app` solves the issue ( see refs below).

# Testing
Use the following example project to demonstrate the solution. The master branch uses the current `cnn-starter-app` and will throw an error when running a test with enzyme. The `enzyme-fix` branch references the `cnn-starter-app#feature/jest-setup-file` package and should run without error.

*Before Fix*
- `git clone https://github.com/harryatoms/example-react-16`
- `npm i`
- `npm test` should fail

*After Fix*
- `git clone https://github.com/harryatoms/example-react-16`
- `git checkout enzyme-fix`
- `npm i`
- `npm test` should succeed ( will output request-animation-frame warning, though not an error )

# Notes
- Uses the `create-react-app` solution by assuming `src/setupTests.js` as the setup file and if this file exists, it will be configured with jest.
-  Another option would be to look for a key in the client application's `package.json` to use as the setup-file and allow applications to opt-in this way.

# References
- [Enzyme; Working with React 16.x](http://airbnb.io/enzyme/docs/installation/react-16.html)
- [create-react-app solution](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/scripts/utils/createJestConfig.js#L17)
- [jest configuration: setupTestFrameworkScriptFile](https://facebook.github.io/jest/docs/en/configuration.html#setuptestframeworkscriptfile-string) 