### PR TITLE
[CORENEWS 372] Webpack 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "style-loader": "0.16.1",
     "webpack": "3.10.0",
     "webpack-bundle-analyzer": "2.4.0",
-    "webpack-dev-middleware": "2.0.2",
+    "webpack-dev-middleware": "2.0.3",
     "webpack-hot-middleware": "2.18.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,9 +41,5 @@
     "webpack-bundle-analyzer": "2.4.0",
     "webpack-dev-middleware": "2.0.3",
     "webpack-hot-middleware": "2.18.0"
-  },
-  "peerDependencies": {
-    "jest": "20.0.4",
-    "webpack": "3.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "assets-webpack-plugin": "3.5.1",
     "babel-core": "6.24.1",
-    "babel-loader": "7.0.0",
+    "babel-loader": "7.1.2",
     "babel-polyfill": "6.23.0",
     "babel-preset-cnn-starter-app": "https://github.com/cnnlabs/babel-preset-cnn-starter-app.git#0.1.1",
     "chalk": "1.1.3",
@@ -22,11 +22,11 @@
     "css-loader": "0.28.0",
     "enzyme": "2.9.1",
     "eslint-loader": "1.7.1",
-    "extract-text-webpack-plugin": "2.1.0",
+    "extract-text-webpack-plugin": "3.0.2",
     "file-loader": "0.11.1",
     "fs-extra": "2.1.2",
     "html-loader": "0.4.5",
-    "html-webpack-plugin": "2.28.0",
+    "html-webpack-plugin": "2.29.0",
     "identity-obj-proxy": "3.0.0",
     "inquirer": "3.0.6",
     "jest": "20.0.4",
@@ -37,9 +37,13 @@
     "react-hot-loader": "3.0.0-beta.6",
     "react-test-renderer": "15.6.1",
     "style-loader": "0.16.1",
-    "webpack": "2.4.1",
+    "webpack": "3.10.0",
     "webpack-bundle-analyzer": "2.4.0",
-    "webpack-dev-middleware": "1.10.1",
+    "webpack-dev-middleware": "2.0.2",
     "webpack-hot-middleware": "2.18.0"
+  },
+  "peerDependencies": {
+    "jest": "20.0.4",
+    "webpack": "3.10.0"
   }
 }


### PR DESCRIPTION
Ticket: http://tickets.turner.com/browse/CORENEWS-372

Upgrading to [webpack 3](https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b) lets us use [ModuleConcatenationPlugin](https://webpack.js.org/plugins/module-concatenation-plugin/), which optimizes bundle sizes and reduces webpack's overhead at runtime.

This also requires updates to some of our webpack dependencies:
* [babel-loader@7.1.2](https://github.com/babel/babel-loader/tree/v7.1.2)
* [extract-text-webpack-plugin@3.0.2](https://github.com/webpack-contrib/extract-text-webpack-plugin/releases/tag/v3.0.2)
* [html-webpack-plugin@2.29.0](https://github.com/jantimon/html-webpack-plugin/releases/tag/2.29.0)
* [webpack-dev-middleware@2.0.3](https://github.com/webpack/webpack-dev-middleware/releases/tag/v2.0.3)
  